### PR TITLE
Fix the symlink name

### DIFF
--- a/build/env.sh
+++ b/build/env.sh
@@ -14,7 +14,7 @@ ethdir="$workspace/src/github.com/pirl"
 if [ ! -L "$ethdir/pirl" ]; then
     mkdir -p "$ethdir"
     cd "$ethdir"
-    ln -s ../../../../../. Iceberg-
+    ln -s ../../../../../. pirl
     cd "$root"
 fi
 


### PR DESCRIPTION
Use the path from `$ethdir`. This fixed docker image build.